### PR TITLE
resource_arm_network_interface.go: Fix #4721

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -549,7 +549,7 @@ func flattenNetworkInterfaceIPConfigurations(ipConfigs *[]network.InterfaceIPCon
 
 		niIPConfig["private_ip_address_allocation"] = strings.ToLower(string(props.PrivateIPAllocationMethod))
 
-		if props.PrivateIPAllocationMethod == network.Static {
+		if props.PrivateIPAddress != nil {
 			niIPConfig["private_ip_address"] = *props.PrivateIPAddress
 		}
 


### PR DESCRIPTION
This fixes the bug mentioned in #4721. 

`private_ip_address` was only filled if allocation method was `Static`. Now also filled if this is set to `Dynamic`.